### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -106,3 +106,20 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is currently signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team and practice sessions",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Soccer Club": {
+        "description": "Join us for soccer games and training",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["james@mergington.edu", "sarah@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Music Band": {
+        "description": "Learn instruments and perform in school concerts",
+        "schedule": "Mondays and Fridays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["lucas@mergington.edu", "ava@mergington.edu"]
+    },
+    "Debate Club": {
+        "description": "Develop public speaking and critical thinking skills",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["noah@mergington.edu"]
+    },
+    "Robotics Team": {
+        "description": "Design and build robots for competitions",
+        "schedule": "Tuesdays and Saturdays, 2:00 PM - 4:00 PM",
+        "max_participants": 14,
+        "participants": ["ethan@mergington.edu", "mia@mergington.edu"]
     }
 }
 
@@ -61,6 +97,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,24 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function escapeHtml(value) {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -20,11 +30,38 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participants = details.participants || [];
+        const participantsMarkup = participants.length
+          ? `<ul class="participants-list">${participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${escapeHtml(participant)}</span>
+                    <button
+                      type="button"
+                      class="participant-remove-btn"
+                      data-activity="${escapeHtml(name)}"
+                      data-email="${escapeHtml(participant)}"
+                      aria-label="Unregister ${escapeHtml(participant)} from ${escapeHtml(name)}"
+                      title="Unregister participant"
+                    >
+                      &times;
+                    </button>
+                  </li>
+                `
+              )
+              .join("")}</ul>`
+          : '<p class="participants-empty">No participants yet.</p>';
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <h5>Participants</h5>
+            ${participantsMarkup}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +99,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +116,49 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const button = event.target.closest(".participant-remove-btn");
+    if (!button) {
+      return;
+    }
+
+    const activity = button.dataset.activity;
+    const email = button.dataset.email;
+
+    if (!activity || !email) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Could not unregister participant.";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,77 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed #cfd8dc;
+}
+
+.participants-section h5 {
+  margin-bottom: 8px;
+  color: #1a237e;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #37474f;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border: 1px solid #d8e2e8;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ffffff 0%, #f6f9fc 100%);
+}
+
+.participant-email {
+  font-size: 0.95rem;
+  color: #253238;
+  word-break: break-all;
+}
+
+.participant-remove-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #f3b5b5;
+  background-color: #fff4f4;
+  color: #c62828;
+  font-size: 1.2rem;
+  line-height: 1;
+  font-weight: bold;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.participant-remove-btn:hover {
+  background-color: #ffe6e6;
+  box-shadow: 0 2px 8px rgba(198, 40, 40, 0.2);
+  transform: translateY(-1px);
+}
+
+.participant-remove-btn:focus-visible {
+  outline: 2px solid #ef9a9a;
+  outline-offset: 2px;
+}
+
+.participants-empty {
+  color: #607d8b;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import app as app_module
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    """Ensure tests do not leak mutations into each other."""
+    original_activities = deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(original_activities)
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_activities_get.py
+++ b/tests/test_activities_get.py
@@ -1,0 +1,16 @@
+def test_get_activities_returns_activity_map(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    activities = response.json()
+
+    assert isinstance(activities, dict)
+    assert "Chess Club" in activities
+    assert "Programming Class" in activities
+
+    for details in activities.values():
+        assert "description" in details
+        assert "schedule" in details
+        assert "max_participants" in details
+        assert "participants" in details
+        assert isinstance(details["participants"], list)

--- a/tests/test_activity_signup.py
+++ b/tests/test_activity_signup.py
@@ -1,0 +1,36 @@
+def test_signup_success_adds_participant(client):
+    email = "new-student@mergington.edu"
+
+    response = client.post("/activities/Chess Club/signup", params={"email": email})
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for Chess Club"
+
+    activities = client.get("/activities").json()
+    assert email in activities["Chess Club"]["participants"]
+
+
+def test_signup_rejects_duplicate_participant(client):
+    response = client.post(
+        "/activities/Chess Club/signup",
+        params={"email": "michael@mergington.edu"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_rejects_unknown_activity(client):
+    response = client.post(
+        "/activities/Unknown Club/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_requires_email_param(client):
+    response = client.post("/activities/Chess Club/signup")
+
+    assert response.status_code == 422

--- a/tests/test_activity_unregister.py
+++ b/tests/test_activity_unregister.py
@@ -1,0 +1,43 @@
+def test_unregister_success_removes_participant(client):
+    email = "daniel@mergington.edu"
+
+    response = client.delete("/activities/Chess Club/signup", params={"email": email})
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {email} from Chess Club"
+
+    activities = client.get("/activities").json()
+    assert email not in activities["Chess Club"]["participants"]
+
+
+def test_unregister_rejects_unknown_activity(client):
+    response = client.delete(
+        "/activities/Unknown Club/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_rejects_unknown_participant(client):
+    response = client.delete(
+        "/activities/Chess Club/signup",
+        params={"email": "not-enrolled@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"
+
+
+def test_signup_then_unregister_flow(client):
+    email = "temp-student@mergington.edu"
+
+    signup_response = client.post("/activities/Robotics Team/signup", params={"email": email})
+    assert signup_response.status_code == 200
+
+    unregister_response = client.delete("/activities/Robotics Team/signup", params={"email": email})
+    assert unregister_response.status_code == 200
+
+    activities = client.get("/activities").json()
+    assert email not in activities["Robotics Team"]["participants"]

--- a/tests/test_root_redirect.py
+++ b/tests/test_root_redirect.py
@@ -1,0 +1,5 @@
+def test_root_redirects_to_static_index(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the student activities app, including enhanced participant management, a more interactive frontend, and comprehensive test coverage. The most significant changes are the addition of unregister functionality, frontend UI enhancements to display and manage participants, and new tests to ensure reliability.

**Backend features and improvements:**

* Added the ability for students to unregister from activities via a new `DELETE /activities/{activity_name}/signup` endpoint, with proper error handling for unknown activities and participants.
* Improved signup logic to prevent duplicate participant registrations in an activity.
* Expanded the list of available activities with detailed descriptions, schedules, and participant lists.

**Frontend enhancements:**

* Updated the activities list UI to show current participants for each activity, including a styled participants section, and added "remove" buttons to allow unregistering participants directly from the interface. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R33-R64) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R147)
* Implemented frontend logic to handle unregistering participants, including API calls, error handling, and UI updates when participants are removed. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R122-R164) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R102)
* Added HTML escaping for participant names and activity names to prevent XSS vulnerabilities.

**Testing improvements:**

* Added fixtures to ensure test isolation and prevent state leakage between tests.
* Implemented test suites for activities retrieval, signup, unregister, and root redirect behaviors, covering edge cases and error conditions. [[1]](diffhunk://#diff-8eef73c8473181569c4157a6a16d5251ec8b2ffe734266e3dca503ddb6d81b3cR1-R16) [[2]](diffhunk://#diff-bf6737f1784985cff449301a83426318eb45891114f724e62a818cfdaa90e489R1-R36) [[3]](diffhunk://#diff-f0776169c56668b668b748c8bc924b3c1c82d8a118f4780faa6d51944020e509R1-R43) [[4]](diffhunk://#diff-221e9bb48798738439a2b32ae0ac86f31b097ee6febc01f406901e485855475cR1-R5)